### PR TITLE
Fix incorrect git url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/benbria/node-logstash-forwarder"
+    "url": "https://github.com/benbria/node-bunyan-lumberjack"
   },
   "dependencies": {
     "lumberjack-protocol": "^1.0.1"


### PR DESCRIPTION
npm uses this link on the module detail page